### PR TITLE
Update net.py

### DIFF
--- a/fusion_report/common/net.py
+++ b/fusion_report/common/net.py
@@ -135,7 +135,7 @@ class Net:
             url: str = f'{Settings.MITELMAN["HOSTNAME"]}/{Settings.MITELMAN["FILE"]}'
             Net.get_large_file(url)
             with ZipFile(Settings.MITELMAN['FILE'], 'r') as archive:
-                files = [x for x in archive.namelist() if "mitelman_db/MBCA.TXT.DATA" in x]
+                files = [x for x in archive.namelist() if "MBCA.TXT.DATA" in x]
                 archive.extractall()
 
             db = MitelmanDB('.')


### PR DESCRIPTION
Addresses issue  #52. The database files were not unzipping to a sub-directory. Removing the incorrect path to `MBCA.TXT.DATA` results in a correct `mitelman.db` build

# Name pull request

Thank you for contribution to `fusion-report` project.

## Checklist

- [ ] Specify in detail the change
- [ ] Make sure to follow guidelines in `docs` when adding database/tool
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README` is updated
